### PR TITLE
feat: seleção de tema (Claro/Escuro/Sistema) nas Configurações

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'com.google.code.geocoder-java:geocoder-java:0.16'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'org.jsoup:jsoup:1.17.2'
+    implementation 'androidx.preference:preference:1.2.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:rules:1.5.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,11 @@
             android:name=".activity.SearchLocation"
             android:label="@string/title_activity_search_location"
             android:theme="@style/AppTheme.NoActionBar"></activity>
+        <activity
+            android:name=".settings.SettingsActivity"
+            android:label="@string/title_activity_settings"
+            android:theme="@style/AppTheme.NoActionBar"
+            android:parentActivityName=".MainActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/novoideal/tabuademares/MainActivity.java
+++ b/app/src/main/java/com/novoideal/tabuademares/MainActivity.java
@@ -1,6 +1,7 @@
 package com.novoideal.tabuademares;
 
 import android.annotation.SuppressLint;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -21,6 +22,8 @@ import com.google.android.material.tabs.TabLayout;
 
 import com.novoideal.tabuademares.adapter.FragmentAdapter;
 import com.novoideal.tabuademares.controller.ExtremesController;
+import com.novoideal.tabuademares.settings.SettingsActivity;
+import com.novoideal.tabuademares.util.ThemeHelper;
 import com.novoideal.tabuademares.controller.MoonController;
 import com.novoideal.tabuademares.controller.SeaConditionController;
 import com.novoideal.tabuademares.controller.WeatherController;
@@ -51,8 +54,11 @@ public class MainActivity extends AppCompatActivity {
     private ViewPager mViewPager;
     private TabLayout tabLayout;
 
+    private static final String KEY_CURRENT_TAB = "current_tab";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        ThemeHelper.applyTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
@@ -65,6 +71,10 @@ public class MainActivity extends AppCompatActivity {
 
         createRefresh();
         setupTabLayout();
+
+        if (savedInstanceState != null) {
+            mViewPager.setCurrentItem(savedInstanceState.getInt(KEY_CURRENT_TAB, 0));
+        }
 
         cleanBD();
     }
@@ -114,7 +124,10 @@ public class MainActivity extends AppCompatActivity {
     @Override
     @SuppressLint("MissingSuperCall")
     protected void onSaveInstanceState(Bundle outState) {
-        //No call for super(). Bug on API Level > 11.
+        // Intentionally no super() call — bug on API Level > 11.
+        if (mViewPager != null) {
+            outState.putInt(KEY_CURRENT_TAB, mViewPager.getCurrentItem());
+        }
     }
 
     private void createViewPager(FragmentStatePagerAdapter fragmentStatePagerAdapter) {
@@ -271,7 +284,7 @@ public class MainActivity extends AppCompatActivity {
         int id = item.getItemId();
 
         if (id == R.id.action_settings) {
-            Snackbar.make(this.mViewPager, "Ainda não implementado", Snackbar.LENGTH_LONG).setAction("Action", null).show();
+            startActivity(new Intent(this, SettingsActivity.class));
             return true;
         }
         if (id == R.id.action_about) {

--- a/app/src/main/java/com/novoideal/tabuademares/settings/SettingsActivity.java
+++ b/app/src/main/java/com/novoideal/tabuademares/settings/SettingsActivity.java
@@ -1,0 +1,38 @@
+package com.novoideal.tabuademares.settings;
+
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import com.novoideal.tabuademares.R;
+import com.novoideal.tabuademares.util.ThemeHelper;
+
+public class SettingsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        ThemeHelper.applyTheme(this);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.settings_container, new SettingsFragment())
+                    .commit();
+        }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+}

--- a/app/src/main/java/com/novoideal/tabuademares/settings/SettingsFragment.java
+++ b/app/src/main/java/com/novoideal/tabuademares/settings/SettingsFragment.java
@@ -1,0 +1,30 @@
+package com.novoideal.tabuademares.settings;
+
+import android.os.Bundle;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+
+import com.novoideal.tabuademares.R;
+import com.novoideal.tabuademares.util.ThemeHelper;
+
+public class SettingsFragment extends PreferenceFragmentCompat {
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.preferences, rootKey);
+
+        ListPreference themePref = findPreference(ThemeHelper.PREF_THEME);
+        if (themePref != null) {
+            themePref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    ThemeHelper.saveAndApply(requireContext(), (String) newValue);
+                    requireActivity().recreate();
+                    return true;
+                }
+            });
+        }
+    }
+}

--- a/app/src/main/java/com/novoideal/tabuademares/util/ThemeHelper.java
+++ b/app/src/main/java/com/novoideal/tabuademares/util/ThemeHelper.java
@@ -1,0 +1,34 @@
+package com.novoideal.tabuademares.util;
+
+import android.content.Context;
+
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.preference.PreferenceManager;
+
+public class ThemeHelper {
+
+    public static final String PREF_THEME = "pref_theme";
+    public static final String THEME_LIGHT = "light";
+    public static final String THEME_DARK = "dark";
+    public static final String THEME_SYSTEM = "system";
+
+    static int toNightMode(String themeValue) {
+        if (THEME_LIGHT.equals(themeValue)) return AppCompatDelegate.MODE_NIGHT_NO;
+        if (THEME_DARK.equals(themeValue)) return AppCompatDelegate.MODE_NIGHT_YES;
+        return AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+    }
+
+    public static void applyTheme(Context context) {
+        String theme = PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(PREF_THEME, THEME_SYSTEM);
+        AppCompatDelegate.setDefaultNightMode(toNightMode(theme));
+    }
+
+    public static int saveAndApply(Context context, String themeValue) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit().putString(PREF_THEME, themeValue).apply();
+        int mode = toNightMode(themeValue);
+        AppCompatDelegate.setDefaultNightMode(mode);
+        return mode;
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/AppTheme.AppBarOverlay"
+        android:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    <FrameLayout
+        android:id="@+id/settings_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,18 @@
     <string name="title_activity_search_location">SearchLocation</string>
     <string name="no_tide_data_city">Dados de marés não disponíveis para esta cidade</string>
     <string name="no_tide_data_date">Sem dados de maré para esta data</string>
+
+    <string name="title_activity_settings">Configurações</string>
+    <string name="pref_theme_title">Tema</string>
+
+    <string-array name="pref_theme_entries">
+        <item>Sistema</item>
+        <item>Claro</item>
+        <item>Escuro</item>
+    </string-array>
+    <string-array name="pref_theme_values">
+        <item>system</item>
+        <item>light</item>
+        <item>dark</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ListPreference
+        app:key="pref_theme"
+        app:title="@string/pref_theme_title"
+        app:entries="@array/pref_theme_entries"
+        app:entryValues="@array/pref_theme_values"
+        app:defaultValue="system"
+        app:useSimpleSummaryProvider="true"
+        app:iconSpaceReserved="false" />
+
+</PreferenceScreen>

--- a/app/src/test/java/com/novoideal/tabuademares/util/ThemeHelperTest.java
+++ b/app/src/test/java/com/novoideal/tabuademares/util/ThemeHelperTest.java
@@ -1,0 +1,40 @@
+package com.novoideal.tabuademares.util;
+
+import androidx.appcompat.app.AppCompatDelegate;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThemeHelperTest {
+
+    @Test
+    public void toNightMode_light_returnsNightNo() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, ThemeHelper.toNightMode("light"));
+    }
+
+    @Test
+    public void toNightMode_dark_returnsNightYes() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_YES, ThemeHelper.toNightMode("dark"));
+    }
+
+    @Test
+    public void toNightMode_system_returnsFollowSystem() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, ThemeHelper.toNightMode("system"));
+    }
+
+    @Test
+    public void toNightMode_unknown_fallsBackToFollowSystem() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, ThemeHelper.toNightMode("unknown"));
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, ThemeHelper.toNightMode(""));
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, ThemeHelper.toNightMode(null));
+    }
+
+    @Test
+    public void constants_haveExpectedValues() {
+        assertEquals("light", ThemeHelper.THEME_LIGHT);
+        assertEquals("dark", ThemeHelper.THEME_DARK);
+        assertEquals("system", ThemeHelper.THEME_SYSTEM);
+        assertEquals("pref_theme", ThemeHelper.PREF_THEME);
+    }
+}

--- a/specs/theme-settings.md
+++ b/specs/theme-settings.md
@@ -1,0 +1,212 @@
+# Theme Settings
+
+> **Status**: Done
+> **Created**: 2026-05-25
+
+## 1. Business Context
+
+### Problem Statement
+
+O app já suporta tema escuro via `Theme.MaterialComponents.DayNight`, mas o usuário não tem controle sobre isso: o tema muda só quando o sistema muda. O menu "Configurações" existe na toolbar porém exibe "Ainda não implementado". Usuários que preferem tema escuro independentemente do sistema — ou que querem forçar o tema claro em um dispositivo com dark mode ativo — não têm como fazer isso. A ausência de controle limita a personalização e torna o botão de Configurações inútil.
+
+### Goals
+
+- Usuário pode escolher entre três opções de tema: **Claro**, **Escuro** e **Sistema**.
+- A escolha persiste entre sessões do app.
+- O tema é aplicado imediatamente ao confirmar a seleção, sem reinicialização manual.
+- O menu "Configurações" abre uma tela funcional em vez de mostrar Snackbar.
+
+### User Stories
+
+#### US-1: Selecionar tema nas Configurações
+
+- **Story**: Como usuário, quero escolher o tema do app nas Configurações, para que o visual corresponda à minha preferência independentemente do modo do sistema.
+- **Acceptance Criteria**:
+  - **Given** o app aberto, **when** o usuário toca em "Configurações" no menu, **then** a tela de Configurações é aberta (não aparece Snackbar).
+  - **Given** a tela de Configurações aberta, **when** o usuário visualiza a seção de tema, **then** três opções são exibidas: "Claro", "Escuro" e "Sistema".
+  - **Given** qualquer opção selecionada, **when** o usuário confirma, **then** o tema é aplicado imediatamente sem fechar e reabrir o app manualmente.
+  - **Given** o app fechado e reaberto, **when** o usuário retorna ao app, **then** o tema previamente escolhido é mantido.
+
+#### US-2: Opção "Sistema" como padrão
+
+- **Story**: Como usuário novo, quero que o app siga o tema do sistema por padrão, para que minha experiência inicial seja coerente com o restante do dispositivo.
+- **Acceptance Criteria**:
+  - **Given** primeiro acesso ao app (sem preferência salva), **when** o usuário abre o app, **then** o tema segue a configuração do sistema operacional.
+  - **Given** tema "Sistema" selecionado, **when** o usuário altera o dark mode nas configurações do Android, **then** o app muda de tema automaticamente.
+
+### Key Scenarios
+
+| Cenário | Pré-condições | Passos | Resultado esperado |
+|---|---|---|---|
+| Ativar tema escuro manualmente | App com tema "Sistema", sistema em modo claro | Abrir Configurações → selecionar "Escuro" → confirmar | App muda imediatamente para tema escuro; próxima abertura mantém o tema escuro |
+| Retornar ao tema do sistema | App com tema "Escuro" forçado | Abrir Configurações → selecionar "Sistema" → confirmar | App volta a seguir o sistema; se sistema estiver claro, app fica claro |
+| Primeira instalação | App recém-instalado, sistema em dark mode | Abrir o app | Tema escuro aplicado automaticamente (padrão "Sistema") |
+| Troca de tema sem perda de estado | Qualquer tema, visualizando aba de Maré | Abrir Configurações → trocar tema → confirmar | Activity recria; usuário retorna à aba de Maré com os dados preservados |
+
+### Functional Requirements
+
+- FR-1: A tela de Configurações deve estar acessível pelo menu "Configurações" na toolbar da `MainActivity`.
+- FR-2: A seção de tema deve apresentar as opções: **Sistema** (padrão), **Claro**, **Escuro**.
+- FR-3: A escolha do tema deve ser persistida em `SharedPreferences`.
+- FR-4: A mudança de tema deve chamar `AppCompatDelegate.setDefaultNightMode()` e recriar a `Activity` atual.
+- FR-5: O tema selecionado deve ser aplicado em `MainActivity.onCreate` antes do `setContentView`.
+
+### Non-Functional Requirements
+
+- NFR-1: A transição de tema não deve causar flash branco visível por mais de um frame.
+- NFR-2: A tela de Configurações deve ser navegável com TalkBack (acessibilidade).
+- NFR-3: A opção selecionada deve ter indicação visual clara do estado atual.
+
+### Out of Scope
+
+- Outras configurações além do tema (notificações, unidades de medida, etc.).
+- Temas customizados além de claro/escuro/sistema.
+- Suporte a Android abaixo da API 15 para dark mode (comportamento de fallback é seguir "Claro").
+
+---
+
+## 2. Arch Decisions
+
+### Proposed Solution
+
+Criar uma `SettingsActivity` com um `PreferenceFragmentCompat` contendo uma `ListPreference` para seleção de tema. A preferência é armazenada em `SharedPreferences` default. A `MainActivity` lê a preferência no `onCreate` e chama `AppCompatDelegate.setDefaultNightMode()` para aplicar o tema antes do layout ser inflado. A `SettingsActivity` também aplica o tema salvo no `onCreate` para garantir consistência visual.
+
+### Architecture Overview
+
+```mermaid
+flowchart TD
+    A[MainMenu → Configurações] --> B[SettingsActivity.onCreate]
+    B --> C[ThemeHelper.applyTheme]
+    C --> D[AppCompatDelegate.setDefaultNightMode]
+    B --> E[SettingsFragment.onCreatePreferences]
+    E --> F[ListPreference: Claro / Escuro / Sistema]
+    F -->|onChange| G[ThemeHelper.saveAndApply]
+    G --> H[SharedPreferences.putString]
+    G --> I[AppCompatDelegate.setDefaultNightMode]
+    I --> J[Activity.recreate]
+
+    K[App cold start] --> L[MainActivity.onCreate]
+    L --> C
+```
+
+### Alternatives Considered
+
+| Alternativa | Prós | Contras | Veredicto |
+|---|---|---|---|
+| `AlertDialog` com RadioGroup | Simples, menos código | Não escala para futuras configurações; fora do padrão Settings do Android | Rejeitado |
+| `BottomSheetDialog` | Visual moderno, fácil UX | Mesmo problema de escalabilidade; sem integração nativa com Preferences | Rejeitado |
+| `PreferenceFragmentCompat` em `SettingsActivity` | Padrão Android, escalável, acessível por padrão, fácil de extender | Requer `activity_settings.xml` e entrada no Manifest | **Aceito** |
+
+### Risks & Mitigations
+
+| Risco | Impacto | Probabilidade | Mitigação |
+|---|---|---|---|
+| Flash branco na transição de tema | Médio | Médio | Aplicar `AppCompatDelegate` antes do `setContentView`; usar `android:windowBackground` coerente no tema |
+| Perda da aba ativa no `recreate()` | Baixo | Alto | Salvar o índice da aba em `onSaveInstanceState` e restaurar no `onCreate` |
+| Inconsistência visual na `SettingsActivity` | Baixo | Baixo | `SettingsActivity.onCreate` chama `ThemeHelper.applyTheme` antes do super |
+
+### Key Decisions
+
+#### Decision 1: `ThemeHelper` como classe utilitária estática
+
+- **Status**: Aceito
+- **Context**: A lógica de ler SharedPreferences e chamar `AppCompatDelegate.setDefaultNightMode()` será chamada de pelo menos duas Activities (`MainActivity` e `SettingsActivity`). Duplicar essa lógica gera risco de inconsistência.
+- **Decision**: Criar `util/ThemeHelper.java` com métodos estáticos `applyTheme(Context)` e `saveAndApply(Context, String)`.
+- **Consequences**: Ponto único para alterar a lógica de tema; sem dependência de DI ou ciclo de vida.
+
+#### Decision 2: Usar `ListPreference` padrão do AndroidX Preference
+
+- **Status**: Aceito
+- **Context**: A UI de seleção de tema pode ser implementada com componentes customizados ou com o sistema de Preferences padrão do AndroidX.
+- **Decision**: Usar `androidx.preference:preference:1.2.x` com `ListPreference`, que fornece diálogo de seleção nativo, bind automático ao `SharedPreferences`, e suporte a TalkBack sem código adicional.
+- **Consequences**: Adicionar a dependência `androidx.preference:preference:1.2.1` ao `build.gradle`. O visual padrão do diálogo de `ListPreference` não é Material 3 puro, mas é funcional e acessível.
+
+### Implementation Plan
+
+1. Adicionar dependência `androidx.preference:preference:1.2.1` ao `app/build.gradle`.
+2. Criar `util/ThemeHelper.java` com a lógica de leitura e aplicação do tema.
+3. Atualizar `MainActivity.onCreate` para chamar `ThemeHelper.applyTheme` antes do `super.onCreate` (ou imediatamente após, antes de `setContentView`).
+4. Criar `res/xml/preferences.xml` com a `ListPreference` de tema.
+5. Criar `SettingsFragment extends PreferenceFragmentCompat`.
+6. Criar `SettingsActivity` com `SettingsFragment` como conteúdo; registrar no `AndroidManifest.xml`.
+7. Atualizar o handler do menu em `MainActivity` para fazer `startActivity(SettingsActivity)`.
+8. Adicionar strings PT-BR: rótulos de opções e título da tela.
+9. Salvar/restaurar índice da aba ativa no `MainActivity` via `onSaveInstanceState`.
+
+---
+
+## 3. Technical Contract
+
+### Data Models
+
+**SharedPreferences** (arquivo default, `Context.getSharedPreferences`):
+
+| Chave | Tipo | Valores possíveis | Padrão |
+|---|---|---|---|
+| `pref_theme` | `String` | `"system"`, `"light"`, `"dark"` | `"system"` |
+
+### Interfaces
+
+**`util/ThemeHelper.java`**
+
+```java
+public class ThemeHelper {
+    static final String PREF_THEME = "pref_theme";
+    static final String THEME_LIGHT  = "light";
+    static final String THEME_DARK   = "dark";
+    static final String THEME_SYSTEM = "system";
+
+    // Lê SharedPreferences e aplica o modo via AppCompatDelegate.
+    // Chamar em onCreate() de toda Activity, antes de setContentView().
+    public static void applyTheme(Context context);
+
+    // Persiste o valor em SharedPreferences e chama applyTheme.
+    // Retorna o AppCompatDelegate mode int aplicado.
+    public static int saveAndApply(Context context, String themeValue);
+}
+```
+
+**`res/xml/preferences.xml`**
+
+```xml
+<PreferenceScreen>
+  <ListPreference
+      app:key="pref_theme"
+      app:title="@string/pref_theme_title"
+      app:entries="@array/pref_theme_entries"
+      app:entryValues="@array/pref_theme_values"
+      app:defaultValue="system"
+      app:useSimpleSummaryProvider="true" />
+</PreferenceScreen>
+```
+
+**String arrays em `res/values/strings.xml`**:
+
+```xml
+<string-array name="pref_theme_entries">
+    <item>Sistema</item>
+    <item>Claro</item>
+    <item>Escuro</item>
+</string-array>
+<string-array name="pref_theme_values">
+    <item>system</item>
+    <item>light</item>
+    <item>dark</item>
+</string-array>
+```
+
+### Integration Points
+
+| Ponto | Como integra |
+|---|---|
+| `MainActivity.onCreate` | Chama `ThemeHelper.applyTheme(this)` antes de `setContentView` |
+| `MainActivity.onOptionsItemSelected` | Substitui o Snackbar "não implementado" por `startActivity(new Intent(this, SettingsActivity.class))` |
+| `SettingsActivity.onCreate` | Chama `ThemeHelper.applyTheme(this)` para garantir tema correto na própria tela de configurações |
+| `SettingsFragment.onPreferenceChange` | Chama `ThemeHelper.saveAndApply` e depois `requireActivity().recreate()` |
+| `AndroidManifest.xml` | Declara `SettingsActivity` com tema `@style/AppTheme.NoActionBar` |
+
+### Invariants & Constraints
+
+- O `ThemeHelper.applyTheme` deve ser chamado **antes** de qualquer `setContentView` em toda Activity que precisar refletir o tema salvo.
+- O valor de `pref_theme` no `SharedPreferences` deve ser sempre um dos três valores definidos (`"system"`, `"light"`, `"dark"`); qualquer valor não reconhecido deve ser tratado como `"system"`.
+- O índice da aba ativa na `MainActivity` deve ser preservado através do `recreate()` para evitar regressão de UX.


### PR DESCRIPTION
## Summary

- **US-1**: Menu "Configurações" agora abre uma `SettingsActivity` real (não mais Snackbar). A tela exibe uma `ListPreference` com as três opções: Sistema, Claro e Escuro.
- **US-2**: Padrão `"system"` — sem preferência salva, o app segue o modo do sistema operacional via `AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM`.
- Troca de tema aplica imediatamente via `AppCompatDelegate.setDefaultNightMode()` e recria a Activity.
- Aba ativa da `MainActivity` é preservada através do `recreate()` via `onSaveInstanceState`.

## Tests

- `ThemeHelperTest` (5 casos): cobre mapeamento de cada valor (`"light"`, `"dark"`, `"system"`, valor desconhecido, `null`) para o modo correto do `AppCompatDelegate`.
- Todos os 20 testes unitários do projeto passam.

## Spec

[specs/theme-settings.md](specs/theme-settings.md)